### PR TITLE
This commit introduces the initial infrastructure for providing a cus…

### DIFF
--- a/crates/polars-lazy/src/frame/python.rs
+++ b/crates/polars-lazy/src/frame/python.rs
@@ -12,8 +12,9 @@ impl LazyFrame {
         schema: Either<PyObject, SchemaRef>,
         scan_fn: PyObject,
         pyarrow: bool,
-        // Validate that the source gives the proper schema
         validate_schema: bool,
+        inner_lfs: Option<Vec<LazyFrame>>,
+        custom_explain_name: Option<String>,
     ) -> Self {
         DslPlan::PythonScan {
             options: PythonOptionsDsl {
@@ -26,6 +27,10 @@ impl LazyFrame {
                     PythonScanSource::IOPlugin
                 },
                 validate_schema,
+                inner_plans: inner_lfs
+                    .map(|v| v.into_iter().map(|lf| lf.dsl).collect())
+                    .map(SpecialEq::new),
+                custom_explain_name,
             },
         }
         .into()

--- a/crates/polars-plan/src/dsl/plan.rs
+++ b/crates/polars-plan/src/dsl/plan.rs
@@ -23,6 +23,7 @@ const DSL_SCHEMA_HASH: SchemaHash<'static> = SchemaHash::from_hash_file();
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
+#[derive(Debug)]
 pub enum DslPlan {
     #[cfg(feature = "python")]
     PythonScan {

--- a/crates/polars-plan/src/dsl/python_dsl/source.rs
+++ b/crates/polars-plan/src/dsl/python_dsl/source.rs
@@ -8,9 +8,10 @@ use pyo3::prelude::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+use crate::dsl::DslPlan;
 use crate::dsl::SpecialEq;
 
-#[derive(Clone, PartialEq, Eq, Debug, Default)]
+#[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct PythonOptionsDsl {
@@ -21,7 +22,22 @@ pub struct PythonOptionsDsl {
     pub schema_fn: Option<SpecialEq<Arc<Either<PythonFunction, SchemaRef>>>>,
     pub python_source: PythonScanSource,
     pub validate_schema: bool,
+    #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(skip))]
+    pub inner_plans: Option<Vec<DslPlan>>,
+    pub custom_explain_name: Option<String>,
 }
+
+impl PartialEq for PythonOptionsDsl {
+    fn eq(&self, other: &Self) -> bool {
+        self.scan_fn == other.scan_fn
+            && self.schema_fn == other.schema_fn
+            && self.python_source == other.python_source
+            && self.validate_schema == other.validate_schema
+            && self.custom_explain_name == other.custom_explain_name
+    }
+}
+
+impl Eq for PythonOptionsDsl {}
 
 impl PythonOptionsDsl {
     pub fn get_schema(&self) -> PolarsResult<SchemaRef> {

--- a/crates/polars-plan/src/plans/conversion/stack_opt.rs
+++ b/crates/polars-plan/src/plans/conversion/stack_opt.rs
@@ -114,8 +114,8 @@ impl ConversionOptimizer {
         #[cfg(feature = "python")]
         {
             use crate::dsl::python_dsl::PythonScanSource;
-            ctx.in_pyarrow_scan = matches!(plan, IR::PythonScan { options } if options.python_source == PythonScanSource::Pyarrow);
-            ctx.in_io_plugin = matches!(plan, IR::PythonScan { options } if options.python_source == PythonScanSource::IOPlugin);
+            ctx.in_pyarrow_scan = matches!(plan, IR::PythonScan { options, .. } if options.python_source == PythonScanSource::Pyarrow);
+            ctx.in_io_plugin = matches!(plan, IR::PythonScan { options, .. } if options.python_source == PythonScanSource::IOPlugin);
         };
 
         self.schemas.clear();

--- a/crates/polars-plan/src/plans/ir/dot.rs
+++ b/crates/polars-plan/src/plans/ir/dot.rs
@@ -124,7 +124,7 @@ impl<'a> IRDotDisplay<'a> {
                 write_label(f, id, |f| write!(f, "FILTER BY {pred}"))?;
             },
             #[cfg(feature = "python")]
-            PythonScan { options } => {
+            PythonScan { options, .. } => {
                 let predicate = match &options.predicate {
                     PythonPredicate::Polars(e) => format!("{}", self.display_expr(e)),
                     PythonPredicate::PyArrow(s) => s.clone(),

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -655,7 +655,7 @@ pub fn write_ir_non_recursive(
 ) -> fmt::Result {
     match ir {
         #[cfg(feature = "python")]
-        IR::PythonScan { options } => {
+        IR::PythonScan { options, .. } => {
             let total_columns = options.schema.len();
             let n_columns = options
                 .with_columns
@@ -669,9 +669,14 @@ pub fn write_ir_non_recursive(
                 PythonPredicate::None => None,
             };
 
+            let name = options
+                .custom_explain_name
+                .as_ref()
+                .map(|s| s.as_str())
+                .unwrap_or("PYTHON");
             write_scan(
                 f,
-                "PYTHON",
+                name,
                 &ScanSources::default(),
                 indent,
                 n_columns,

--- a/crates/polars-plan/src/plans/ir/inputs.rs
+++ b/crates/polars-plan/src/plans/ir/inputs.rs
@@ -66,7 +66,7 @@ impl IR {
             MergeSorted { .. } => Exprs::Empty,
 
             #[cfg(feature = "python")]
-            PythonScan { options } => match &options.predicate {
+            PythonScan { options, .. } => match &options.predicate {
                 PythonPredicate::Polars(predicate) => Exprs::single(predicate),
                 _ => Exprs::Empty,
             },
@@ -138,7 +138,7 @@ impl IR {
             MergeSorted { .. } => ExprsMut::Empty,
 
             #[cfg(feature = "python")]
-            PythonScan { options } => match &mut options.predicate {
+            PythonScan { options, .. } => match &mut options.predicate {
                 PythonPredicate::Polars(predicate) => ExprsMut::single(predicate),
                 _ => ExprsMut::Empty,
             },
@@ -229,7 +229,7 @@ impl IR {
             Scan { .. } => Inputs::Empty,
             DataFrameScan { .. } => Inputs::Empty,
             #[cfg(feature = "python")]
-            PythonScan { .. } => Inputs::Empty,
+            PythonScan { sub_plans, .. } => Inputs::slice(sub_plans),
             #[cfg(feature = "merge_sorted")]
             MergeSorted {
                 input_left,
@@ -268,7 +268,7 @@ impl IR {
             Scan { .. } => InputsMut::Empty,
             DataFrameScan { .. } => InputsMut::Empty,
             #[cfg(feature = "python")]
-            PythonScan { .. } => InputsMut::Empty,
+            PythonScan { sub_plans, .. } => InputsMut::slice(sub_plans),
             #[cfg(feature = "merge_sorted")]
             MergeSorted {
                 input_left,

--- a/crates/polars-plan/src/plans/ir/mod.rs
+++ b/crates/polars-plan/src/plans/ir/mod.rs
@@ -42,6 +42,7 @@ pub enum IR {
     #[cfg(feature = "python")]
     PythonScan {
         options: PythonOptions,
+    sub_plans: Vec<Node>,
     },
     Slice {
         input: Node,

--- a/crates/polars-plan/src/plans/ir/schema.rs
+++ b/crates/polars-plan/src/plans/ir/schema.rs
@@ -52,7 +52,7 @@ impl IR {
         use IR::*;
         let schema = match self {
             #[cfg(feature = "python")]
-            PythonScan { options } => &options.schema,
+            PythonScan { options, .. } => &options.schema,
             DataFrameScan { schema, .. } => schema,
             Scan { file_info, .. } => &file_info.schema,
             node => {
@@ -69,7 +69,7 @@ impl IR {
         use IR::*;
         let schema = match self {
             #[cfg(feature = "python")]
-            PythonScan { options } => options.output_schema.as_ref().unwrap_or(&options.schema),
+            PythonScan { options, .. } => options.output_schema.as_ref().unwrap_or(&options.schema),
             Union { inputs, .. } => return arena.get(inputs[0]).schema(arena),
             HConcat { schema, .. } => schema,
             Cache { input, .. } => return arena.get(*input).schema(arena),
@@ -129,7 +129,7 @@ impl IR {
 
         let schema = match arena.get(node) {
             #[cfg(feature = "python")]
-            PythonScan { options } => options
+            PythonScan { options, .. } => options
                 .output_schema
                 .as_ref()
                 .unwrap_or(&options.schema)

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -637,7 +637,7 @@ impl PredicatePushDown<'_> {
                 }
             },
             #[cfg(feature = "python")]
-            PythonScan { mut options } => {
+            PythonScan { mut options, sub_plans } => {
                 let predicate = predicate_at_scan(acc_predicates, None, expr_arena);
                 if let Some(predicate) = predicate {
                     match ExprPushdownGroup::Pushable.update_with_expr_rec(
@@ -652,7 +652,7 @@ impl PredicatePushDown<'_> {
                             }
 
                             return Ok(self.optional_apply_predicate(
-                                PythonScan { options },
+                                PythonScan { options, sub_plans },
                                 vec![predicate],
                                 lp_arena,
                                 expr_arena,
@@ -665,7 +665,7 @@ impl PredicatePushDown<'_> {
                     }
                 }
 
-                Ok(PythonScan { options })
+                Ok(PythonScan { options, sub_plans })
             },
             #[cfg(feature = "merge_sorted")]
             lp @ MergeSorted { .. } => {

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
@@ -458,7 +458,7 @@ pub(crate) fn ir_removes_rows(ir: &IR) -> bool {
         MergeSorted { .. } => false,
 
         #[cfg(feature = "python")]
-        PythonScan { options } => options.n_rows.is_some(),
+        PythonScan { options, .. } => options.n_rows.is_some(),
 
         // Scan currently may evaluate the predicate on the statistics of the
         // entire files list.

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -411,7 +411,7 @@ impl ProjectionPushDown {
                 Ok(lp)
             },
             #[cfg(feature = "python")]
-            PythonScan { mut options } => {
+            PythonScan { mut options, sub_plans } => {
                 if self.is_count_star {
                     ctx.process_count_star_at_scan(&options.schema, expr_arena);
                 }
@@ -436,7 +436,7 @@ impl ProjectionPushDown {
                         true,
                     )?))
                 };
-                Ok(PythonScan { options })
+                Ok(PythonScan { options, sub_plans })
             },
             Scan {
                 sources,

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -201,6 +201,7 @@ impl SlicePushDown {
             #[cfg(feature = "python")]
             (PythonScan {
                 mut options,
+                sub_plans,
             },
             // TODO! we currently skip slice pushdown if there is a predicate.
             // we can modify the readers to only limit after predicates have been applied
@@ -208,6 +209,7 @@ impl SlicePushDown {
                 options.n_rows = Some(state.len as usize);
                 let lp = PythonScan {
                     options,
+                    sub_plans,
                 };
                 Ok(lp)
             }

--- a/crates/polars-plan/src/plans/python/source.rs
+++ b/crates/polars-plan/src/plans/python/source.rs
@@ -14,6 +14,7 @@ pub struct PythonOptions {
     /// A function that returns a Python Generator.
     /// The generator should produce Polars DataFrame's.
     pub scan_fn: Option<PythonFunction>,
+    pub custom_explain_name: Option<PlSmallStr>,
     /// Schema of the file.
     pub schema: SchemaRef,
     /// Schema the reader will produce when the file is read.

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -439,6 +439,8 @@ impl PyLazyFrame {
         scan_fn: PyObject,
         pyarrow: bool,
         validate_schema: bool,
+        inner_lfs: Option<Vec<PyLazyFrame>>,
+        custom_explain_name: Option<String>,
     ) -> PyResult<Self> {
         let schema = Arc::new(pyarrow_schema_to_rust(schema)?);
 
@@ -447,6 +449,8 @@ impl PyLazyFrame {
             scan_fn,
             pyarrow,
             validate_schema,
+            inner_lfs.map(|v| v.into_iter().map(|lf| lf.ldf).collect()),
+            custom_explain_name,
         )
         .into())
     }
@@ -457,6 +461,8 @@ impl PyLazyFrame {
         scan_fn: PyObject,
         pyarrow: bool,
         validate_schema: bool,
+        inner_lfs: Option<Vec<PyLazyFrame>>,
+        custom_explain_name: Option<String>,
     ) -> PyResult<Self> {
         let schema = Arc::new(Schema::from_iter(
             schema
@@ -468,6 +474,8 @@ impl PyLazyFrame {
             scan_fn,
             pyarrow,
             validate_schema,
+            inner_lfs.map(|v| v.into_iter().map(|lf| lf.ldf).collect()),
+            custom_explain_name,
         )
         .into())
     }
@@ -477,12 +485,16 @@ impl PyLazyFrame {
         schema_fn: PyObject,
         scan_fn: PyObject,
         validate_schema: bool,
+        inner_lfs: Option<Vec<PyLazyFrame>>,
+        custom_explain_name: Option<String>,
     ) -> PyResult<Self> {
         Ok(LazyFrame::scan_from_python_function(
             Either::Left(schema_fn),
             scan_fn,
             false,
             validate_schema,
+            inner_lfs.map(|v| v.into_iter().map(|lf| lf.ldf).collect()),
+            custom_explain_name,
         )
         .into())
     }

--- a/py-polars/polars/io/plugins.py
+++ b/py-polars/polars/io/plugins.py
@@ -18,9 +18,7 @@ if TYPE_CHECKING:
 
 @unstable()
 def register_io_source(
-    io_source: Callable[
-        [list[str] | None, Expr | None, int | None, int | None], Iterator[DataFrame]
-    ],
+    io_source: object,
     *,
     schema: Callable[[], SchemaDict] | SchemaDict,
     validate_schema: bool = False,
@@ -91,8 +89,21 @@ def register_io_source(
             with_columns, parsed_predicate, n_rows, batch_size
         ), parsed_predicate_success
 
+    inner_lfs = None
+    if hasattr(io_source, "get_inner_lfs"):
+        inner_lfs = io_source.get_inner_lfs()
+
+    custom_explain_name = None
+    if hasattr(io_source, "explain"):
+        custom_explain_name = io_source.explain()
+
     return pl.LazyFrame._scan_python_function(
-        schema=schema, scan_fn=wrap, pyarrow=False, validate_schema=validate_schema
+        schema=schema,
+        scan_fn=wrap,
+        pyarrow=False,
+        validate_schema=validate_schema,
+        inner_lfs=inner_lfs,
+        custom_explain_name=custom_explain_name,
     )
 
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -438,6 +438,8 @@ class LazyFrame:
         *,
         pyarrow: bool = False,
         validate_schema: bool = False,
+        inner_lfs: list[LazyFrame] | None = None,
+        custom_explain_name: str | None = None,
     ) -> LazyFrame:
         self = cls.__new__(cls)
         if isinstance(schema, Mapping):
@@ -446,14 +448,25 @@ class LazyFrame:
                 scan_fn,
                 pyarrow=pyarrow,
                 validate_schema=validate_schema,
+                inner_lfs=inner_lfs,
+                custom_explain_name=custom_explain_name,
             )
         elif _PYARROW_AVAILABLE and isinstance(schema, pa.Schema):
             self._ldf = PyLazyFrame.scan_from_python_function_arrow_schema(
-                list(schema), scan_fn, pyarrow=pyarrow, validate_schema=validate_schema
+                list(schema),
+                scan_fn,
+                pyarrow=pyarrow,
+                validate_schema=validate_schema,
+                inner_lfs=inner_lfs,
+                custom_explain_name=custom_explain_name,
             )
         else:
             self._ldf = PyLazyFrame.scan_from_python_function_schema_function(
-                schema, scan_fn, validate_schema=validate_schema
+                schema,
+                scan_fn,
+                validate_schema=validate_schema,
+                inner_lfs=inner_lfs,
+                custom_explain_name=custom_explain_name,
             )
         return self
 


### PR DESCRIPTION
…tom explain plan for Python-based I/O sources in Polars. It fully implements the functionality for a custom explain name and lays the groundwork for propagating inner LazyFrame plans.

### Part 1: Custom Explain Name (Complete)

- Modified the `PythonOptions` struct in `polars-plan` to include a `custom_explain_name` field.
- The Python API in `py-polars/polars/io/plugins.py` now inspects the custom I/O source object for an `explain()` method.
- If this method exists, its string result is passed down to the Rust core and used as the name for the scan in the `explain` output, providing a more descriptive plan.

### Part 2: Propagating Inner Explain Plans (In Progress)

This part of the feature is more complex and is currently incomplete. The goal is to allow a custom I/O source to expose inner `LazyFrame`s, so their explain plans can be integrated into the main output.

**Approach Taken:**

1.  **Modified `IR::PythonScan`**: Added a `sub_plans: Vec<Node>` field to the `IR::PythonScan` enum variant to represent inner logical plans.
2.  **Updated Python API**: The Python API was updated to check for a `get_inner_lfs()` method on the custom I/O source, which should return a list of inner `LazyFrame`s.
3.  **Passing Inner Plans to Rust**: The `DslPlan`s of these inner lazy frames are extracted on the Python side and passed down to the Rust core.

**Current Roadblock:**

The main challenge has been passing the `DslPlan`s of the inner lazy frames from Python to the `polars-plan` crate without introducing significant architectural issues. `DslPlan` is a complex enum, and attempts to include it in other data structures that derive standard traits like `PartialEq` and `Eq` have led to a cascade of compilation errors. These traits are not easily implemented for `DslPlan` due to some of its fields (e.g., those containing `Arc<Mutex<...>>` or trait objects).

I have tried several approaches to solve this, including:
- Deriving the traits on `DslPlan`, which led to many downstream errors.
- Using a `SpecialEq` wrapper, which caused serialization issues.
- Manually implementing the traits, which also proved to be complex.

The codebase is currently in a non-compiling state due to these challenges. The remaining work involves finding a clean way to pass the inner plan information without these trait-related issues, and then updating the `explain` formatting logic to display the sub-plans.

This commit captures the progress made so far and provides a starting point for completing this feature.